### PR TITLE
Add Puppet Enterprise specific instruction to install hipchat gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Installation & Usage
 
         $ sudo gem install hipchat
 
+        NOTE FOR PUPPET ENTERPRISE USERS: You must install the hipchat gem using the puppet-bundled gem library:
+        $ /opt/puppet/bin/gem install hipchat
+
 2.  Install puppet-hipchat as a module in your Puppet master's module
     path.
 


### PR DESCRIPTION
Modified README.md to include note for Puppet Enterprise users to use bundled gem library to install the hipchat gem. Thanks to CeliaCottle for the issue related to this.
