### PR TITLE
Rename of conf option hipchat_room_color in example file

### DIFF
--- a/hipchat.yaml
+++ b/hipchat.yaml
@@ -1,5 +1,5 @@
 ---
 :hipchat_api: 'apikey'
 :hipchat_room: 'roomname'
-:hipchat_room_color: 'red'
+:hipchat_notify_color: 'red'
 :hipchat_notify: 'false'


### PR DESCRIPTION
The name hipchat_room_color is misleading as it's not used in the code.
Proper name is hipchat_notify_color.
