### PR TITLE
Add support for the Puppet Dashboard

### DIFF
--- a/lib/puppet/reports/hipchat.rb
+++ b/lib/puppet/reports/hipchat.rb
@@ -18,6 +18,7 @@ Puppet::Reports.register_report(:hipchat) do
   HIPCHAT_NOTIFY = config[:hipchat_notify]
   HIPCHAT_STATUSES = Array(config[:hipchat_statuses] || 'failed')
   HIPCHAT_PUPPETBOARD = config[:hipchat_puppetboard]
+  HIPCHAT_DASHBOARD = config[:hipchat_dashboard]
 
   # set the default colors if not defined in the config
   HIPCHAT_FAILED_COLOR = config[:failed_color] || 'red'
@@ -68,6 +69,8 @@ Puppet::Reports.register_report(:hipchat) do
         msg = "Puppet run for #{self.host} #{emote(self.status)} #{self.status} at #{Time.now.asctime} on #{self.configuration_version} in #{self.environment}"
         if HIPCHAT_PUPPETBOARD != 'false'
           msg << ": #{HIPCHAT_PUPPETBOARD}/report/latest/#{self.host}"
+        elsif HIPCHAT_DASHBOARD != 'false'
+          msg << ": #{HIPCHAT_DASHBOARD}/nodes/#{self.host}/view"
         end
         if HIPCHAT_PROXY
           client = HipChat::Client.new(HIPCHAT_API, :http_proxy => HIPCHAT_PROXY)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,7 @@
+# Class: puppet_hipchat
+#
+# Send Puppet report information to HipChat
+#
 class puppet_hipchat (
   $api_key,
   $room,
@@ -10,6 +14,7 @@ class puppet_hipchat (
   $owner        = $puppet_hipchat::params::owner,
   $group        = $puppet_hipchat::params::group,
   $puppetboard  = $puppet_hipchat::params::puppetboard,
+  $dashboard    = $puppet_hipchat::params::dashboard,
 ) inherits puppet_hipchat::params {
 
   file { $config_file:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,12 @@
+# Class: puppet_hipchat::params
+#
+# Parameterize for Puppet platform.
+#
 class puppet_hipchat::params {
 
   $package_name = 'hipchat'
   $puppetboard  = 'false'
+  $dashbaord    = 'false'
 
   if $::is_pe == 'true' {
     $puppetconf_path = '/etc/puppetlabs/puppet'

--- a/templates/hipchat.yaml.erb
+++ b/templates/hipchat.yaml.erb
@@ -8,3 +8,4 @@
   - <%= status %>
 <% end -%>
 :hipchat_puppetboard: <%= scope.lookupvar('puppet_hipchat::puppetboard') %>
+:hipchat_dashboard: <%= scope.lookupvar('puppet_hipchat::dashboard') %>


### PR DESCRIPTION
This work adds support for the Puppet Dashboard, which as of this
writing is used by Puppet Enterprise.
