### PR TITLE
Added support for v2 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Usage
 
     $ touch /etc/puppet/hipchat_disabled
 
+* Modern hipchat installations may not support the default v1 api set
+  `hipchat_api_version` to v2 for modern api support.
+
 Author
 ------
 

--- a/lib/puppet/reports/hipchat.rb
+++ b/lib/puppet/reports/hipchat.rb
@@ -20,6 +20,7 @@ Puppet::Reports.register_report(:hipchat) do
   HIPCHAT_STATUSES = Array(config[:hipchat_statuses] || 'failed')
   HIPCHAT_PUPPETBOARD = config[:hipchat_puppetboard]
   HIPCHAT_DASHBOARD = config[:hipchat_dashboard]
+  HIPCHAT_API_VERSION = config[:hipchat_api_version] || 'v1'
 
   # set the default colors if not defined in the config
   HIPCHAT_FAILED_COLOR = config[:failed_color] || 'red'
@@ -74,9 +75,9 @@ Puppet::Reports.register_report(:hipchat) do
           msg << ": #{HIPCHAT_DASHBOARD}/nodes/#{self.host}/view"
         end
         if HIPCHAT_PROXY
-          client = HipChat::Client.new(HIPCHAT_API, :http_proxy => HIPCHAT_PROXY, :server_url => HIPCHAT_SERVER)
+          client = HipChat::Client.new(HIPCHAT_API, :http_proxy => HIPCHAT_PROXY, :api_version => HIPCHAT_API_VERSION, :server_url => HIPCHAT_SERVER)
         else
-          client = HipChat::Client.new(HIPCHAT_API, :server_url => HIPCHAT_SERVER)
+          client = HipChat::Client.new(HIPCHAT_API, :api_version => HIPCHAT_API_VERSION, :server_url => HIPCHAT_SERVER)
         end
         client[HIPCHAT_ROOM].send('Puppet', msg, :notify => HIPCHAT_NOTIFY, :color => color(self.status), :message_format => 'text')
     end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class puppet_hipchat (
   $group          = $puppet_hipchat::params::group,
   $puppetboard    = $puppet_hipchat::params::puppetboard,
   $dashboard      = $puppet_hipchat::params::dashboard,
+  $api_version    = $puppet_hipchat::params::api_version,
 ) inherits puppet_hipchat::params {
 
   file { $config_file:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class puppet_hipchat::params {
   $package_name   = 'hipchat'
   $puppetboard    = false
   $dashboard      = false
+  $api_version    = 'v1'
 
   if str2bool($::is_pe) {
     $install_hc_gem  = true
@@ -14,7 +15,7 @@ class puppet_hipchat::params {
     $provider        = 'pe_gem'
     $owner           = 'pe-puppet'
     $group           = 'pe-puppet'
-  } elsif versioncmp('4.0.0', $::puppetversion) < 1 {
+  } elsif ($::puppetversion) and (versioncmp('4.0.0', $::puppetversion) < 1) {
     $puppetconf_path = '/etc/puppetlabs/puppet'
     $install_hc_gem  = false
     $owner           = 'puppet'

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -9,6 +9,12 @@ describe 'puppet_hipchat', :type => :class do
     it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_api: 'mykey'/) }
     it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_room: 'myroom'/) }
     it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_server: 'myserver'/) }
+    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_api_version: 'v1'\n/) }
+  end
+
+  describe "use api version 2" do
+    let(:params) {{  :api_key => 'mykey', :room => 'myroom', :server => 'myserver', :api_version => 'v2' }}
+    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_api_version: 'v2'/) }
   end
 
   describe "specify file location" do

--- a/templates/hipchat.yaml.erb
+++ b/templates/hipchat.yaml.erb
@@ -3,7 +3,8 @@
 :hipchat_server: '<%= @server %>'
 :hipchat_room: '<%= @room %>'
 :hipchat_notify_color: '<%= @notify_color %>'
-:hipchat_notify: <%= @notify_room %>
+:hipchat_notify: '<%= @notify_room %>'
+:hipchat_api_version: '<%= @api_version %>'
 :hipchat_statuses:
 <% @statuses.each do |status| -%>
   - <%= status %>


### PR DESCRIPTION
Modern on premise hipchat installations are lacking v1 api support, adding v2 support