### PR TITLE
General code quality improvements

### DIFF
--- a/lib/puppet/reports/hipchat.rb
+++ b/lib/puppet/reports/hipchat.rb
@@ -13,6 +13,17 @@ Puppet::Reports.register_report(:hipchat) do
   raise(Puppet::ParseError, "Hipchat report config file #{configfile} not readable") unless File.exist?(configfile)
   config = YAML.load_file(configfile)
 
+  #due to previous code stringifying false in place of undef we need to hard set those values to undef if 'false' for backward compatibility
+  if config[:hipchat_dashboard] == 'false'
+    config.delete(':hipchat_dashboard')
+  end
+  if config[:hipchat_dashboard] == 'false'
+    config.delete(':hipchat_dashboard')
+  end
+  if config[:hipchat_proxy] == 'false'
+    config.delete(':hipchat_proxy')
+  end
+
   HIPCHAT_API = config[:hipchat_api]
   HIPCHAT_SERVER = config[:hipchat_server]
   HIPCHAT_ROOM = config[:hipchat_room]
@@ -28,7 +39,7 @@ Puppet::Reports.register_report(:hipchat) do
   HIPCHAT_UNCHANGED_COLOR = config[:unchanged_color] || 'gray'
 
   DISABLED_FILE = File.join([File.dirname(Puppet.settings[:config]), 'hipchat_disabled'])
-  HIPCHAT_PROXY = config[:hipchat_proxy]
+  HIPCHAT_PROXY = config[:hipchat_proxy] || ENV['http_proxy']
 
   if HIPCHAT_PROXY && (RUBY_VERSION < '1.9.3' || Gem.loaded_specs["hipchat"].version < Gem::Version.new('1.0.0'))
     raise(Puppet::SettingsError, "hipchat_proxy requires ruby >= 1.9.3 and hipchat gem >= 1.0.0")
@@ -69,16 +80,13 @@ Puppet::Reports.register_report(:hipchat) do
     if (HIPCHAT_STATUSES.include?(self.status) || HIPCHAT_STATUSES.include?('all')) && !disabled
       Puppet.debug "Sending status for #{self.host} to Hipchat channel #{HIPCHAT_ROOM}"
         msg = "Puppet run for #{self.host} #{emote(self.status)} #{self.status} at #{Time.now.asctime} on #{self.configuration_version} in #{self.environment}"
-        if HIPCHAT_PUPPETBOARD != 'false'
+        if HIPCHAT_PUPPETBOARD
           msg << ": #{HIPCHAT_PUPPETBOARD}/report/latest/#{self.host}"
-        elsif HIPCHAT_DASHBOARD != 'false'
+        elsif HIPCHAT_DASHBOARD
           msg << ": #{HIPCHAT_DASHBOARD}/nodes/#{self.host}/view"
         end
-        if HIPCHAT_PROXY
-          client = HipChat::Client.new(HIPCHAT_API, :http_proxy => HIPCHAT_PROXY, :api_version => HIPCHAT_API_VERSION, :server_url => HIPCHAT_SERVER)
-        else
-          client = HipChat::Client.new(HIPCHAT_API, :api_version => HIPCHAT_API_VERSION, :server_url => HIPCHAT_SERVER)
-        end
+        
+        client = HipChat::Client.new(HIPCHAT_API, :http_proxy => HIPCHAT_PROXY, :api_version => HIPCHAT_API_VERSION, :server_url => HIPCHAT_SERVER)
         client[HIPCHAT_ROOM].send('Puppet', msg, :notify => HIPCHAT_NOTIFY, :color => color(self.status), :message_format => 'text')
     end
   end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class puppet_hipchat (
   $puppetboard    = $puppet_hipchat::params::puppetboard,
   $dashboard      = $puppet_hipchat::params::dashboard,
   $api_version    = $puppet_hipchat::params::api_version,
+  $proxy          = $puppet_hipchat::params::proxy,
 ) inherits puppet_hipchat::params {
 
   file { $config_file:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,9 +5,10 @@
 class puppet_hipchat::params {
 
   $package_name   = 'hipchat'
-  $puppetboard    = false
-  $dashboard      = false
+  $puppetboard    = undef
+  $dashboard      = undef
   $api_version    = 'v1'
+  $proxy          = undef
 
   if str2bool($::is_pe) {
     $install_hc_gem  = true

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -6,15 +6,18 @@ describe 'puppet_hipchat', :type => :class do
   describe "default" do
     let(:params) { { :api_key => 'mykey', :room => 'myroom', :server => 'myserver' } }
     it { should contain_package('hipchat').with(:provider => 'gem') }
-    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_api: 'mykey'/) }
-    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_room: 'myroom'/) }
-    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_server: 'myserver'/) }
-    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_api_version: 'v1'\n/) }
+    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_api: mykey/) }
+    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_room: myroom/) }
+    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_server: myserver/) }
+    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_api_version: v1\n/) }
+    it { should contain_file('/etc/puppet/hipchat.yaml').without(:content => /:hipchat_proxy:/) }
+    it { should contain_file('/etc/puppet/hipchat.yaml').without(:content => /:hipchat_puppetboard:/) }
+    it { should contain_file('/etc/puppet/hipchat.yaml').without(:content => /:hipchat_dashboard:/) }
   end
 
   describe "use api version 2" do
     let(:params) {{  :api_key => 'mykey', :room => 'myroom', :server => 'myserver', :api_version => 'v2' }}
-    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_api_version: 'v2'/) }
+    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_api_version: v2/) }
   end
 
   describe "specify file location" do
@@ -41,4 +44,18 @@ describe 'puppet_hipchat', :type => :class do
     it { should contain_file('/etc/puppetlabs/puppet/hipchat.yaml') }
   end
 
+  describe 'with proxy' do
+    let(:params) { { :api_key => 'mykey', :room => 'myroom', :server => 'myserver', :proxy => 'myproxy' } }
+    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_proxy: myproxy\n/) }
+  end
+
+  describe 'with puppetboard' do
+    let(:params) { { :api_key => 'mykey', :room => 'myroom', :server => 'myserver', :puppetboard => 'mypuppetboard' } }
+    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_puppetboard: mypuppetboard\n/) }
+  end
+
+  describe 'with puppetboard' do
+    let(:params) { { :api_key => 'mykey', :room => 'myroom', :server => 'myserver', :dashboard => 'mydashboard' } }
+    it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_dashboard: mydashboard\n/) }
+  end
 end

--- a/templates/hipchat.yaml.erb
+++ b/templates/hipchat.yaml.erb
@@ -1,13 +1,20 @@
 ---
-:hipchat_api: '<%= @api_key %>'
-:hipchat_server: '<%= @server %>'
-:hipchat_room: '<%= @room %>'
-:hipchat_notify_color: '<%= @notify_color %>'
-:hipchat_notify: '<%= @notify_room %>'
-:hipchat_api_version: '<%= @api_version %>'
+:hipchat_api: <%= @api_key %>
+:hipchat_server: <%= @server %>
+:hipchat_room: <%= @room %>
+:hipchat_notify_color: <%= @notify_color %>
+:hipchat_notify: <%= @notify_room %>
+:hipchat_api_version: <%= @api_version %>
 :hipchat_statuses:
 <% @statuses.each do |status| -%>
   - <%= status %>
 <% end -%>
+<% if @puppetboard -%>
 :hipchat_puppetboard: <%= @puppetboard %>
+<% end -%>
+<% if @dashboard -%>
 :hipchat_dashboard: <%= @dashboard %>
+<% end -%>
+<% if @proxy -%>
+:hipchat_proxy: <%= @proxy %>
+<% end -%>


### PR DESCRIPTION
Changes made
1: force stringified false to be undef, this supports backwards compatibility

2: hipchat gem fails back to using environmental variable for proxy config,
given the error logging we need to fall back as well (requires 1)

3: hipchat pivots proxy on if defined, passing nil is an acceptable, as such the if statement is not required so long as undef / false is passed (requires 1)

4: added management of proxy settings into module config template

5: added spec tests for puppetboard and dashboard settings in config file

6: rather than setting strings to false, they should be not written to the config file at all. This will cause the config to evaluate as nil.

7: since 1 de-stringed booleans, removed checks for 'false'

8: none of the valid values in the yaml config file would receive special meaning, removing quotes