### PR TITLE
Implemented puppetboard report link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,9 @@ group :unit_tests do
   gem 'json',                    :require => false
 end
 group :development do
-  gem 'simplecov',   :require => false
-  gem 'guard-rake',  :require => false
+  gem 'simplecov',       :require => false
+  gem 'guard-rake',      :require => false
+  gem 'listen', '3.0.7', :require => false # version 3.1+ removed support for ruby version <2.2
 end
 group :system_tests do
   gem 'vagrant-wrapper',  :require => false

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ Usage
   node's latest report will be send with the message to HipChat. An
   example file is included.
 
+  *NOTE FOR PUPPETBOARD 0.1.2+ USERS*: if you are using environments other than production
+  you will need to either configure puppetboard default environment to * or set `hipchat_server`
+  to append /%2A, ex: `:hipchat_server: http://hipchat.test.local/%2A` otherwise you will receive
+  a not found error for nodes in environments which are not production.
+
 * To temporarily disable HipChat notifications add a file named
   `hipchat_disabled` in the same path as `hipchat.yaml`. Removing it
   will re-enable notifications.

--- a/hipchat.yaml
+++ b/hipchat.yaml
@@ -1,5 +1,6 @@
 ---
 :hipchat_api: 'apikey'
+:hipchat_api_version: 'v1'
 :hipchat_room: 'roomname'
 :hipchat_notify_color: 'red'
 :hipchat_notify: 'false'

--- a/lib/puppet/reports/hipchat.rb
+++ b/lib/puppet/reports/hipchat.rb
@@ -81,7 +81,7 @@ Puppet::Reports.register_report(:hipchat) do
       Puppet.debug "Sending status for #{self.host} to Hipchat channel #{HIPCHAT_ROOM}"
         msg = "Puppet run for #{self.host} #{emote(self.status)} #{self.status} at #{Time.now.asctime} on #{self.configuration_version} in #{self.environment}"
         if HIPCHAT_PUPPETBOARD
-          msg << ": #{HIPCHAT_PUPPETBOARD}/report/latest/#{self.host}"
+          msg << ": #{HIPCHAT_PUPPETBOARD}/report/#{self.host}/#{self.configuration_version}"
         elsif HIPCHAT_DASHBOARD
           msg << ": #{HIPCHAT_DASHBOARD}/nodes/#{self.host}/view"
         end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,11 +4,11 @@
 #
 class puppet_hipchat::params {
 
-  $package_name   = 'hipchat'
-  $puppetboard    = undef
-  $dashboard      = undef
-  $api_version    = 'v1'
-  $proxy          = undef
+  $package_name = 'hipchat'
+  $puppetboard  = undef
+  $dashboard    = undef
+  $api_version  = 'v1'
+  $proxy        = undef
 
   if str2bool($::is_pe) {
     $install_hc_gem  = true

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -54,7 +54,7 @@ describe 'puppet_hipchat', :type => :class do
     it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_puppetboard: mypuppetboard\n/) }
   end
 
-  describe 'with puppetboard' do
+  describe 'with dashboard' do
     let(:params) { { :api_key => 'mykey', :room => 'myroom', :server => 'myserver', :dashboard => 'mydashboard' } }
     it { should contain_file('/etc/puppet/hipchat.yaml').with(:content => /:hipchat_dashboard: mydashboard\n/) }
   end


### PR DESCRIPTION
Per #38 while puppetboard does not have the ability to specify a specific configuration version, and the puppetboard report_id is not known to the puppet report processor, we can provide a link to the reports interface for the specific node. This allows the consumer to drill into the last failed report with trivial effort. I believe this is much more useful than using /report/latest.